### PR TITLE
GCP Stackdriver Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Apache Kafka Integration Pack
-This pack allows integration with [Apache Kafka](http://kafka.apache.org/), high-throughput distributed messaging system.
+This pack allows integration with [Apache Kafka](http://kafka.apache.org/), high-throughput distributed messaging system.  The KafkaGCPMessageSensor enables support for encoded GCP stackdriver formatted messages.  Empowering Stackstorm with the ability to consume service provider level event information from Google Cloud.  For more information on configuring stackdriver to PubSub to Kafka integration, please see https://github.com/GoogleCloudPlatform/pubsub/tree/master/kafka-connector 
 
 ## Actions
 * `kafka.produce` - Send *message* categorized by *topic* to Kafka *hosts*.
@@ -18,6 +18,19 @@ When receives new data, it emits:
   * `offset` - Consumer offset for current topic. Position of what has been consumed (integer).
   * `key` - Message's key, used only for keyed messages (string).
 
+### KafkaGCPMessageSensor
+Connects to a Kafka broker, subscribing to various topics containing GCP stackdriver messages with base64 encoded payloads. The sensor decodes the payload and dispatches triggers for each new message.
+
+When receives new data, it emits:
+* trigger: `kafka.new_GCPmessage`
+* payload:
+  * `topic` - Category from which message was retrieved (string).
+  * `message` - Message. JSON-serialized messages are converted to objects (object|string).
+  * `partition` - Topic partition number message belongs to (integer).
+  * `offset` - Consumer offset for current topic. Position of what has been consumed (integer).
+  * `key` - Message's key, used only for keyed messages (string).
+
+
 #### Configuration
 * `hosts` - Default hosts to send `produce` messages to in host:port format.
             Comma-separated for several hosts. (ex: `localhost:9092`)
@@ -27,6 +40,11 @@ When receives new data, it emits:
   * `topics` - Listen for new messages on these topics, (ex: `['test', 'meetings']`)
   * `group_id` - Consumer group (default: `st2-sensor-group`)
   * `client_id` - Client ID to identify application making the request (default: `st2-kafka-consumer`).
+* gcp_message_sensor:
+  * `hosts` - Kafka hostname(s) to connect in host:port format. Comma-separated for several hosts. (ex: `localhost:9092`)
+  * `topics` - Listen for new messages with base64 encoded payloads on these topics, (ex: `['stackdriver', 'base64_messages']`)
+  * `group_id` - Consumer group (default: `st2gcpgroup`)
+  * `client_id` - Client ID to identify application making the request (default: `st2gcpclient`).
 
 ## Examples
 Send message to Kafka queue:

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -7,7 +7,7 @@
   client_id:
     description: "Unique client ID to identify ourselves when sending"
     type: "string"
-    default: "testclientID"
+    default: "st2-kafka-producer"
     required: true
 
   message_sensor:

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -51,7 +51,7 @@
         default: "172.16.1.10:9092"
         required: true
       topics:
-        description: "List of base64 encoed topics for the sensor to subscribe to"
+        description: "List of base64 encoded topics for the sensor to subscribe to"
         type: "array"
         items:
           type: "string"
@@ -60,10 +60,10 @@
       group_id:
         description: "The sensors group ID"
         type: "string"
-        default: "testgroupID"
+        default: "st2gcpgroup"
         required: true
       client_id:
         description: "The sensors client ID"
         type: "string"
-        default: "testclientID"
+        default: "st2gcpclient"
         required: true

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -13,7 +13,7 @@
   message_sensor:
     description: "Sensor specific settings"
     type: "object"
-    required: true
+    required: false
     additionalProperties: true
     properties:
       hosts:

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -38,3 +38,32 @@
         type: "string"
         default: "testclientID"
         required: true
+
+  gcp_message_sensor:
+    description: "GCP sensor specific settings"
+    type: "object"
+    required: true
+    additionalProperties: true
+    properties:
+      hosts:
+        description: "List of Kafka brokers hosts:port for sensor to connect to"
+        type: "string"
+        default: "172.16.1.10:9092"
+        required: true
+      topics:
+        description: "List of base64 encoed topics for the sensor to subscribe to"
+        type: "array"
+        items:
+          type: "string"
+          default: "test"
+          required: true
+      group_id:
+        description: "The sensors group ID"
+        type: "string"
+        default: "testgroupID"
+        required: true
+      client_id:
+        description: "The sensors client ID"
+        type: "string"
+        default: "testclientID"
+        required: true

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -42,7 +42,7 @@
   gcp_message_sensor:
     description: "GCP sensor specific settings"
     type: "object"
-    required: true
+    required: false
     additionalProperties: true
     properties:
       hosts:

--- a/kafka.yaml.example
+++ b/kafka.yaml.example
@@ -1,8 +1,8 @@
 ---
 # Used by the produce action
-client_id: testclientID
+client_id: st2-kafka-producer
 hosts: 172.16.1.10:9092
-# Used for the sensor
+# Used for the kafka sensor
 message_sensor:
   client_id: testclientID
   group_id: testgroupID
@@ -11,8 +11,8 @@ message_sensor:
   - test
 # Used by the gcp kafka sensor
 gcp_message_sensor:
-  client_id: GCPtestclientID
-  group_id: GCPtestgroupID
+  client_id: st2gcpclient
+  group_id: st2gcpgroup
   hosts: 172.16.1.10:9092
   topics:
   - gcp_stackdriver_topic

--- a/kafka.yaml.example
+++ b/kafka.yaml.example
@@ -8,5 +8,11 @@ message_sensor:
   group_id: testgroupID
   hosts: 172.16.1.10:9092
   topics:
-  - digital_logging_os
   - test
+# Used by the gcp kafka sensor
+gcp_message_sensor:
+  client_id: GCPtestclientID
+  group_id: GCPtestgroupID
+  hosts: 172.16.1.10:9092
+  topics:
+  - gcp_stackdriver_topic

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,8 @@ keywords:
   - message broker
   - gcp
   - base64
+  - stackdriver
+  - google cloud
 version: 0.2.1
 author: StackStorm
 email: support@stackstorm.com

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,9 @@ keywords:
   - queuing
   - messaging
   - message broker
-version: 0.2.0
+  - gcp
+  - base64
+version: 0.2.1
 author: StackStorm
 email: support@stackstorm.com
 Contributors:

--- a/sensors/gcp_message_sensor.py
+++ b/sensors/gcp_message_sensor.py
@@ -1,0 +1,121 @@
+import json
+from st2reactor.sensor.base import Sensor
+from kafka import KafkaConsumer
+
+
+class KafkaGCPMessageSensor(Sensor):
+    """
+    Read multiple topics from Apache Kafka cluster and auto-commit offset (mark tasks as finished).
+    If responded topic message is JSON - try to convert it to object for reuse inside st2.
+    """
+    TRIGGER = 'kafka.new_message'
+    DEFAULT_GROUP_ID = 'st2-gcp-sensor-group'
+    DEFAULT_CLIENT_ID = 'st2-gcp-kafka-consumer'
+
+    def __init__(self, sensor_service, config=None):
+        """
+        Parse config variables, set defaults.
+        """
+        super(KafkaGCPMessageSensor, self).__init__(sensor_service=sensor_service, config=config)
+        self._logger = self._sensor_service.get_logger(__name__)
+
+        gcp_message_sensor = self._config.get('gcp_message_sensor')
+        if not gcp_message_sensor:
+            raise ValueError('[KafkaGCPMessageSensor]: "gcp_message_sensor" config value is required!')
+
+        self._hosts = gcp_message_sensor.get('hosts')
+        if not self._hosts:
+            raise ValueError(
+                '[KafkaGCPMessageSensor]: "gcp_message_sensor.hosts" config value is required!')
+
+        self._topics = set(gcp_message_sensor.get('topics', []))
+        if not self._topics:
+            raise ValueError(
+                '[KafkaGCPMessageSensor]: "gcp_message_sensor.topics" should list at least one topic!')
+
+        # set defaults for empty values
+        self._group_id = gcp_message_sensor.get('group_id') or self.DEFAULT_GROUP_ID
+        self._client_id = gcp_message_sensor.get('client_id') or self.DEFAULT_CLIENT_ID
+        self._consumer = None
+
+    def setup(self):
+        """
+        Create connection and initialize Kafka Consumer.
+        """
+        self._logger.debug('[KafkaGCPMessageSensor]: Initializing consumer ...')
+        self._consumer = KafkaConsumer(*self._topics,
+                                       client_id=self._client_id,
+                                       group_id=self._group_id,
+                                       bootstrap_servers=self._hosts,
+                                       deserializer_class=self._try_deserialize)
+        self._ensure_topics_existence()
+
+    def _ensure_topics_existence(self):
+        """
+        Ensure that topics we're listening to exist.
+
+        Fetching metadata for a non-existent topic will automatically try to create it
+        with the default replication factor and number of partitions (default server config).
+        Otherwise Kafka server is not configured to auto-create topics and partitions.
+        """
+        map(self._consumer._client.ensure_topic_exists, self._topics)
+        self._consumer.set_topic_partitions(*self._topics)
+
+    def run(self):
+        """
+        Run infinite loop, continuously reading for Kafka message bus,
+        dispatch trigger with payload data if message received.
+        """
+        self._logger.debug('[KafkaGCPMessageSensor]: Entering into listen mode ...')
+
+        for message in self._consumer:
+            message.value['payload']['message'] = message.value['payload']['message'].decode('base64')
+            self._logger.debug(
+                "[KafkaGCPMessageSensor]: Received %s:%d:%d: key=%s message=%s" %
+                (message.topic, message.partition,
+                 message.offset, message.key, message.value)
+            )
+            payload = {
+                'topic': message.topic,
+                'partition': message.partition,
+                'offset': message.offset,
+                'key': message.key,
+                'message': message.value,
+            }
+            self._sensor_service.dispatch(trigger=self.TRIGGER, payload=payload)
+            # Mark this message as fully consumed
+            self._consumer.task_done(message)
+            self._consumer.commit()
+
+    def cleanup(self):
+        """
+        Close connection, just to be sure.
+        """
+        self._consumer._client.close()
+
+    def add_trigger(self, trigger):
+        pass
+
+    def update_trigger(self, trigger):
+        pass
+
+    def remove_trigger(self, trigger):
+        pass
+
+    @staticmethod
+    def _try_deserialize(body):
+        """
+        Try to deserialize received message body.
+        Convert it to object for future reuse in st2 work chain.
+
+        :param body: Raw message body.
+        :rtype body: ``str``
+        :return: Parsed message as object or original string if deserialization failed.
+        :rtype: ``str|object``
+        """
+        try:
+            body = json.loads(body)
+        except Exception:
+            pass
+
+        return body

--- a/sensors/gcp_message_sensor.py
+++ b/sensors/gcp_message_sensor.py
@@ -8,9 +8,9 @@ class KafkaGCPMessageSensor(Sensor):
     Read multiple topics from Apache Kafka cluster and auto-commit offset (mark tasks as finished).
     If responded topic message is JSON - try to convert it to object for reuse inside st2.
     """
-    TRIGGER = 'kafka.new_message'
-    DEFAULT_GROUP_ID = 'st2-gcp-sensor-group'
-    DEFAULT_CLIENT_ID = 'st2-gcp-kafka-consumer'
+    TRIGGER = 'kafka.new_GCPmessage'
+    DEFAULT_GROUP_ID = 'st2gcpgroup'
+    DEFAULT_CLIENT_ID = 'st2gcpclient'
 
     def __init__(self, sensor_service, config=None):
         """

--- a/sensors/gcp_message_sensor.py
+++ b/sensors/gcp_message_sensor.py
@@ -21,7 +21,8 @@ class KafkaGCPMessageSensor(Sensor):
 
         gcp_message_sensor = self._config.get('gcp_message_sensor')
         if not gcp_message_sensor:
-            raise ValueError('[KafkaGCPMessageSensor]: "gcp_message_sensor" config value is required!')
+            raise ValueError(
+                '[KafkaGCPMessageSensor]: "gcp_message_sensor" config value is required!')
 
         self._hosts = gcp_message_sensor.get('hosts')
         if not self._hosts:
@@ -31,7 +32,8 @@ class KafkaGCPMessageSensor(Sensor):
         self._topics = set(gcp_message_sensor.get('topics', []))
         if not self._topics:
             raise ValueError(
-                '[KafkaGCPMessageSensor]: "gcp_message_sensor.topics" should list at least one topic!')
+                '[KafkaGCPMessageSensor]: "gcp_message_sensor.topics" \
+                 should list at least one topic!')
 
         # set defaults for empty values
         self._group_id = gcp_message_sensor.get('group_id') or self.DEFAULT_GROUP_ID
@@ -69,7 +71,8 @@ class KafkaGCPMessageSensor(Sensor):
         self._logger.debug('[KafkaGCPMessageSensor]: Entering into listen mode ...')
 
         for message in self._consumer:
-            message.value['payload']['message'] = message.value['payload']['message'].decode('base64')
+            message.value['payload']['message'] = message.\
+                value['payload']['message'].decode('base64')
             self._logger.debug(
                 "[KafkaGCPMessageSensor]: Received %s:%d:%d: key=%s message=%s" %
                 (message.topic, message.partition,

--- a/sensors/gcp_message_sensor.yaml
+++ b/sensors/gcp_message_sensor.yaml
@@ -1,0 +1,25 @@
+---
+class_name: KafkaGCPMessageSensor
+entry_point: gcp_message_sensor.py
+description: "Sensor which monitors Kafka broker for gcp stackdriver messages"
+trigger_types:
+  - name: new_GCPmessage
+    description: "Trigger which indicates that a new GCP format message has arrived"
+    payload_schema:
+      type: object
+      properties:
+        topic:
+          description: "Category from which message was retrieved"
+          type: string
+        message:
+          description: "Captured message. JSON-serialized messages are automatically parsed"
+          type: object
+        partition:
+          description: "Topic partition number message belongs to"
+          type: integer
+        offset:
+          description: "Consumer offset for current topic. Position of what has been consumed"
+          type: integer
+        key:
+          description: "Message's key (only for keyed messages)"
+          type: string

--- a/sensors/gcp_message_sensor.yaml
+++ b/sensors/gcp_message_sensor.yaml
@@ -12,7 +12,7 @@ trigger_types:
           description: "Category from which message was retrieved"
           type: string
         message:
-          description: "Captured message. JSON-serialized messages are automatically parsed"
+          description: "Captured message. JSON-serialized messages are automatically parsed. payload.message is base64 decoded"
           type: object
         partition:
           description: "Topic partition number message belongs to"


### PR DESCRIPTION
Adding support for GCP stackdriver messages over kafka.  Separate sensor consumes encoded stackdriver topics and shows events in plain text.