### PR TITLE
Fix trigger payload schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.2.3
+
+- Sensor payload parameter schema for ``KafkaMessageSensor`` and ``KafkaGCPMessageSensor`` sensor
+  has been fixed so trigger dispatching works correctly under StackStorm >= 2.9.0 where trigger
+  payload validation is enabled by default. #7 #8

--- a/pack.yaml
+++ b/pack.yaml
@@ -10,7 +10,7 @@ keywords:
   - base64
   - stackdriver
   - google cloud
-version: 0.2.2
+version: 0.2.3
 author: StackStorm
 email: support@stackstorm.com
 Contributors:

--- a/sensors/gcp_message_sensor.yaml
+++ b/sensors/gcp_message_sensor.yaml
@@ -13,7 +13,9 @@ trigger_types:
           type: string
         message:
           description: "Captured message. JSON-serialized messages are automatically parsed. payload.message is base64 decoded"
-          type: object
+          type:
+            - string
+            - object
         partition:
           description: "Topic partition number message belongs to"
           type: integer

--- a/sensors/message_sensor.yaml
+++ b/sensors/message_sensor.yaml
@@ -13,7 +13,9 @@ trigger_types:
           type: string
         message:
           description: "Captured message. JSON-serialized messages are automatically parsed"
-          type: object
+          type:
+            - string
+            - object
         partition:
           description: "Topic partition number message belongs to"
           type: integer


### PR DESCRIPTION
Per #7, message can be either a string or object.

This pull request updates the schema definition to take that into account.

Resolves #7.