### PR TITLE
Fixes no attribute '__dict__'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Vscode
+.vscode/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.4
+
+- `ProduceResponse` has no `__dict__` attribute. So this version changes the `produce.py` to return the results of the `_as_dict` method instead
+
 ## 0.2.3
 
 - Sensor payload parameter schema for ``KafkaMessageSensor`` and ``KafkaGCPMessageSensor`` sensor

--- a/actions/produce.py
+++ b/actions/produce.py
@@ -42,4 +42,4 @@ class ProduceMessageAction(Action):
         result = producer.send_messages(topic, kafka_bytestring(message))
 
         if result[0]:
-            return result[0].__dict__
+            return result[0]._asdict()

--- a/pack.yaml
+++ b/pack.yaml
@@ -10,7 +10,7 @@ keywords:
   - base64
   - stackdriver
   - google cloud
-version: 0.2.3
+version: 0.2.4
 author: StackStorm
 email: support@stackstorm.com
 Contributors:


### PR DESCRIPTION
Per #6, the result `ProduceResponse` does not contain `__dict__`

This pull request changes the result to return `_asdict()`

Resolves #6 .